### PR TITLE
Fix album art url

### DIFF
--- a/index.iced
+++ b/index.iced
@@ -46,7 +46,7 @@ checkSong = ->
 
 postSong = (track) ->
   isBroke = false
-  albumArtURL = "http://#{config.sonosIpAddress}:1400#{track.albumArtURL}"
+  albumArtURL = track.albumArtURL
   lastArtist = track.artist
   lastTitle = track.title
   oneLiner = "#{track.artist} - #{track.title}"


### PR DESCRIPTION
`albumArtURL` contains the IP Address for the Sonos, so it was returning an invalid URI

e.g.

``` json
{
  "title": "Feel The Volume",
  "artist": "Jauz",
  "album": "Feel The Volume",
  "albumArtURI": "/getaa?s=1&u=x-sonos-spotify%3aspotify%253atrack%253a6RyXxSHs7VZSgQH4hjrg7L%3fsid%3d9%26flags%3d8224%26sn%3d34",
  "position": 0,
  "duration": 230,
  "albumArtURL": "http://11.1.111.111:1400/getaa?s=1&u=x-sonos-spotify%3aspotify%253atrack%253a6RyXxSHs7VZSgQH4hjrg7L%3fsid%3d9%26flags%3d8224%26sn%3d34"
}
```
