### PR TITLE
Add IP to the albumArtURL if it isn't present

### DIFF
--- a/index.iced
+++ b/index.iced
@@ -45,8 +45,12 @@ checkSong = ->
     postSong(track)
 
 postSong = (track) ->
-  isBroke = false
   albumArtURL = track.albumArtURL
+
+  if albumArtURL.length && !albumArtURL.startsWith('http')
+    albumArtURL = "http://#{config.sonosIpAddress}:1400#{albumArtURL}"
+
+  isBroke = false
   lastArtist = track.artist
   lastTitle = track.title
   oneLiner = "#{track.artist} - #{track.title}"


### PR DESCRIPTION
Compatibility for the case where the albumArtURL isn't returned with the Sonos IP address. 

See: https://github.com/ewiner/sonoslack/pull/5#issuecomment-221816815
